### PR TITLE
[Definitely] An informal audit

### DIFF
--- a/audit/src/EthPlaysV0.sol
+++ b/audit/src/EthPlaysV0.sol
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+
+import {Poke} from "src/Poke.sol";
+import {RegistryReceiverV0} from "src/RegistryReceiverV0.sol";
+
+/// @title An experiment in collaborative gaming
+/// @author olias.eth
+/// @notice This is experimental software, use at your own risk.
+contract EthPlaysV0 is Ownable {
+    /* -------------------------------------------------------------------------- */
+    /*                                   STRUCTS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    struct ControlBid {
+        address from;
+        uint256 amount;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   STORAGE                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice [Contract] The POKE token contract
+    Poke public poke;
+    /// @notice [Contract] The EthPlays registry contract
+    RegistryReceiverV0 public registryReceiver;
+
+    /// @notice [Parameter] Indicates if the game is currently active
+    bool public isActive;
+
+    /// @notice [State] The index of the last executed input
+    uint256 public inputIndex;
+    /// @notice [State] The block timestamp of the previous input
+    uint256 private inputTimestamp;
+
+    /// @notice [Parameter] The fraction of alignment to persist upon decay, out of 1000
+    uint256 public alignmentDecayRate;
+    /// @notice [Parameter] Number of seconds between alignment votes for each account
+    uint256 public alignmentVoteCooldown;
+    /// @notice [Parameter] The current reward (in POKE) for voting for chaos
+    uint256 public chaosVoteReward;
+    /// @notice [State] Timestamp of latest alignment vote by account address
+    mapping(address => uint256) private alignmentVoteTimestamps;
+    /// @notice [State] The current alignment value
+    int256 public alignment;
+
+    /// @notice [Parameter] Number of seconds in the order vote period
+    uint256 public orderDuration;
+    /// @notice [State] Count of order votes for each button index, by input index
+    uint256[8] private orderVotes;
+    /// @notice [State] Most recent inputIndex an account submitted an order vote
+    mapping(address => uint256) private inputIndices;
+
+    /// @notice [State] Timestamp of the most recent chaos input for each account
+    mapping(address => uint256) private chaosInputTimestamps;
+    /// @notice [Parameter] Number of seconds of cooldown between chaos rewards
+    uint256 public chaosInputRewardCooldown;
+
+    /// @notice [Parameter] The current reward (in POKE) for chaos inputs, subject to cooldown
+    uint256 public chaosInputReward;
+    /// @notice [Parameter] The current reward (in POKE) for order input votes
+    uint256 public orderInputReward;
+    /// @notice [Parameter] The current cost (in POKE) to submit a chat message
+    uint256 public chatCost;
+    /// @notice [Parameter] The current cost (in POKE) to buy a rare candy
+    uint256 public rareCandyCost;
+
+    /// @notice [Parameter] The number of seconds that the control auction lasts
+    uint256 public controlAuctionDuration;
+    /// @notice [Parameter] The number of seconds that control lasts
+    uint256 public controlDuration;
+    /// @notice [State] The best bid for the current control auction
+    ControlBid private bestControlBid;
+    /// @notice [State] The block timestamp of the start of the latest control auction
+    uint256 public controlAuctionStartTimestamp;
+    /// @notice [State] The block timestamp of the end of the latest control auction
+    uint256 public controlAuctionEndTimestamp;
+    /// @notice [State] The account that has (or most recently had) control
+    address public controlAddress;
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   EVENTS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    // Gameplay events
+    event AlignmentVote(address from, bool vote, int256 alignment);
+    event InputVote(uint256 inputIndex, address from, uint256 buttonIndex);
+    event ButtonInput(uint256 inputIndex, address from, uint256 buttonIndex);
+    event Chat(address from, string message);
+    event RareCandy(address from, uint256 count);
+
+    // Auction events
+    event NewControlBid(address from, uint256 amount);
+    event Control(address from);
+
+    // Parameter update events
+    event SetIsActive(bool isActive);
+    event SetAlignmentDecayRate(uint256 alignmentDecayRate);
+    event SetChaosVoteReward(uint256 chaosVoteReward);
+    event SetOrderDuration(uint256 orderDuration);
+    event SetChaosInputRewardCooldown(uint256 chaosInputRewardCooldown);
+    event SetChaosInputReward(uint256 chaosInputReward);
+    event SetOrderInputReward(uint256 orderInputReward);
+    event SetChatCost(uint256 chatCost);
+    event SetRareCandyCost(uint256 rareCandyCost);
+    event SetControlAuctionDuration(uint256 controlAuctionDuration);
+    event SetControlDuration(uint256 controlDuration);
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   ERRORS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    // Gameplay errors
+    error GameNotActive();
+    error AccountNotRegistered();
+    error InvalidButtonIndex();
+    error AnotherPlayerHasControl();
+    error AlreadyVotedForThisInput();
+    error AlignmentVoteCooldown();
+
+    // Redeem errors
+    error InsufficientBalanceForRedeem();
+
+    // Auction errors
+    error InsufficientBalanceForBid();
+    error InsufficientBidAmount();
+    error AuctionInProgress();
+    error AuctionIsOver();
+    error AuctionHasNoBids();
+
+    /* -------------------------------------------------------------------------- */
+    /*                                 MODIFIERS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Requires the game to be active.
+    modifier onlyActive() {
+        if (!isActive) {
+            revert GameNotActive();
+        }
+        _;
+    }
+
+    /// @notice Requires the sender to be a registered account.
+    modifier onlyRegistered() {
+        if (!registryReceiver.isRegistered(msg.sender)) {
+            revert AccountNotRegistered();
+        }
+        _;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                               INITIALIZATION                               */
+    /* -------------------------------------------------------------------------- */
+
+    constructor(Poke _poke, RegistryReceiverV0 _registryReceiver) {
+        poke = _poke;
+        registryReceiver = _registryReceiver;
+
+        isActive = true;
+
+        alignmentVoteCooldown = 60;
+        alignmentDecayRate = 985;
+        chaosVoteReward = 40e18;
+
+        orderDuration = 20;
+        chaosInputRewardCooldown = 30;
+
+        chaosInputReward = 20e18;
+        orderInputReward = 20e18;
+        chatCost = 20e18;
+        rareCandyCost = 200e18;
+
+        controlAuctionDuration = 90;
+        controlDuration = 30;
+        bestControlBid = ControlBid(address(0), 0);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                  GAMEPLAY                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Submit an alignment vote.
+    /// @param _alignmentVote The alignment vote. True corresponds to order, false to chaos.
+    function submitAlignmentVote(bool _alignmentVote)
+        external
+        onlyActive
+        onlyRegistered
+    {
+        if (
+            block.timestamp <
+            alignmentVoteTimestamps[msg.sender] + alignmentVoteCooldown
+        ) {
+            revert AlignmentVoteCooldown();
+        }
+
+        // Mint tokens to the sender if the vote is for Chaos.
+        if (!_alignmentVote) {
+            poke.gameMint(msg.sender, chaosVoteReward);
+        }
+
+        // Apply alignment decay.
+        alignment *= int256(alignmentDecayRate);
+        alignment /= int256(1000);
+
+        // Apply sender alignment update.
+        alignment += _alignmentVote ? int256(1000) : -1000;
+
+        alignmentVoteTimestamps[msg.sender] = block.timestamp;
+        emit AlignmentVote(msg.sender, _alignmentVote, alignment);
+    }
+
+    /// @notice Submit a button input.
+    /// @param buttonIndex The index of the button input. Must be between 0 and 7.
+    function submitButtonInput(uint256 buttonIndex)
+        external
+        onlyActive
+        onlyRegistered
+    {
+        if (buttonIndex > 7) {
+            revert InvalidButtonIndex();
+        }
+
+        if (block.timestamp <= controlAuctionEndTimestamp + controlDuration) {
+            // Control
+            if (msg.sender != controlAddress) {
+                revert AnotherPlayerHasControl();
+            }
+
+            inputTimestamp = block.timestamp;
+            emit ButtonInput(inputIndex, msg.sender, buttonIndex);
+            inputIndex++;
+        } else if (alignment > 0) {
+            // Order
+
+            orderVotes[buttonIndex]++;
+
+            // If orderDuration seconds have passed since the previous input, execute.
+            // This path could/should be broken out into an external "executeOrderVote"
+            // function that rewards the sender in POKE.
+            if (block.timestamp >= inputTimestamp + orderDuration) {
+                uint256 bestButtonIndex = 0;
+                uint256 bestButtonIndexVoteCount = 0;
+
+                for (uint256 i = 0; i < 8; i++) {
+                    if (orderVotes[i] > bestButtonIndexVoteCount) {
+                        bestButtonIndex = i;
+                        bestButtonIndexVoteCount = orderVotes[i];
+                    }
+                    orderVotes[i] = 0;
+                }
+
+                inputTimestamp = block.timestamp;
+                emit ButtonInput(inputIndex, msg.sender, bestButtonIndex);
+                inputIndex++;
+            } else {
+                if (inputIndex == inputIndices[msg.sender]) {
+                    revert AlreadyVotedForThisInput();
+                }
+                inputIndices[msg.sender] = inputIndex;
+
+                poke.gameMint(msg.sender, orderInputReward);
+                emit InputVote(inputIndex, msg.sender, buttonIndex);
+            }
+        } else {
+            // Chaos
+            if (
+                block.timestamp >
+                chaosInputTimestamps[msg.sender] + chaosInputRewardCooldown
+            ) {
+                chaosInputTimestamps[msg.sender] = block.timestamp;
+                poke.gameMint(msg.sender, chaosInputReward);
+            }
+
+            inputTimestamp = block.timestamp;
+            emit ButtonInput(inputIndex, msg.sender, buttonIndex);
+            inputIndex++;
+        }
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                  REDEEMS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Submit an message to the chat.
+    /// @param message The chat message.
+    function submitChat(string memory message)
+        external
+        onlyActive
+        onlyRegistered
+    {
+        if (poke.balanceOf(msg.sender) < chatCost) {
+            revert InsufficientBalanceForRedeem();
+        }
+
+        poke.gameBurn(msg.sender, chatCost);
+        emit Chat(msg.sender, message);
+    }
+
+    /// @notice Submit a request to purchase rare candies.
+    /// @param count The number of rare candies to be purchased.
+    function submitRareCandies(uint256 count)
+        external
+        onlyActive
+        onlyRegistered
+    {
+        uint256 totalCost = rareCandyCost * count;
+
+        if (poke.balanceOf(msg.sender) < totalCost) {
+            revert InsufficientBalanceForRedeem();
+        }
+
+        poke.gameBurn(msg.sender, totalCost);
+        emit RareCandy(msg.sender, count);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                  AUCTIONS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Submit a bid in the active control auction.
+    /// @param amount The bid amount in POKE
+    function submitControlBid(uint256 amount)
+        external
+        onlyActive
+        onlyRegistered
+    {
+        // This is the first bid in the auction, so set controlAuctionStartTimestamp.
+        if (bestControlBid.from == address(0)) {
+            controlAuctionStartTimestamp = block.timestamp;
+        }
+
+        // The auction is over (it must be ended).
+        if (
+            block.timestamp >
+            controlAuctionStartTimestamp + controlAuctionDuration
+        ) {
+            revert AuctionIsOver();
+        }
+
+        if (poke.balanceOf(msg.sender) < amount) {
+            revert InsufficientBalanceForBid();
+        }
+
+        if (amount <= bestControlBid.amount) {
+            revert InsufficientBidAmount();
+        }
+
+        // If there was a previous best bid, return the bid amount to the account that submitted it.
+        if (bestControlBid.from != address(0)) {
+            poke.gameMint(bestControlBid.from, bestControlBid.amount);
+        }
+        poke.gameBurn(msg.sender, amount);
+        bestControlBid = ControlBid(msg.sender, amount);
+        emit NewControlBid(msg.sender, amount);
+    }
+
+    /// @notice End the current control auction and start the cooldown for the next one.
+    function endControlAuction() external onlyActive {
+        if (
+            block.timestamp <
+            controlAuctionStartTimestamp + controlAuctionDuration
+        ) {
+            revert AuctionInProgress();
+        }
+
+        if (bestControlBid.from == address(0)) {
+            revert AuctionHasNoBids();
+        }
+
+        emit Control(bestControlBid.from);
+        controlAddress = bestControlBid.from;
+        bestControlBid = ControlBid(address(0), 0);
+        controlAuctionEndTimestamp = block.timestamp;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   ADMIN                                    */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Set the isActive parameter. Owner only.
+    /// @param _isActive New value for the isActive parameter
+    function setIsActive(bool _isActive) external onlyOwner {
+        isActive = _isActive;
+        emit SetIsActive(_isActive);
+    }
+
+    function setAlignmentDecayRate(uint256 _alignmentDecayRate)
+        external
+        onlyOwner
+    {
+        alignmentDecayRate = _alignmentDecayRate;
+        emit SetAlignmentDecayRate(_alignmentDecayRate);
+    }
+
+    function setChaosVoteReward(uint256 _chaosVoteReward) external onlyOwner {
+        chaosVoteReward = _chaosVoteReward;
+        emit SetChaosVoteReward(_chaosVoteReward);
+    }
+
+    function setOrderDuration(uint256 _orderDuration) external onlyOwner {
+        orderDuration = _orderDuration;
+        emit SetOrderDuration(_orderDuration);
+    }
+
+    function setChaosInputRewardCooldown(uint256 _chaosInputRewardCooldown)
+        external
+        onlyOwner
+    {
+        chaosInputRewardCooldown = _chaosInputRewardCooldown;
+        emit SetChaosInputRewardCooldown(_chaosInputRewardCooldown);
+    }
+
+    function setChaosInputReward(uint256 _chaosInputReward) external onlyOwner {
+        chaosInputReward = _chaosInputReward;
+        emit SetChaosInputReward(_chaosInputReward);
+    }
+
+    function setOrderInputReward(uint256 _orderInputReward) external onlyOwner {
+        orderInputReward = _orderInputReward;
+        emit SetOrderInputReward(_orderInputReward);
+    }
+
+    function setChatCost(uint256 _chatCost) external onlyOwner {
+        chatCost = _chatCost;
+        emit SetChatCost(_chatCost);
+    }
+
+    function setRareCandyCost(uint256 _rareCandyCost) external onlyOwner {
+        rareCandyCost = _rareCandyCost;
+        emit SetRareCandyCost(_rareCandyCost);
+    }
+
+    function setControlAuctionDuration(uint256 _controlAuctionDuration)
+        external
+        onlyOwner
+    {
+        controlAuctionDuration = _controlAuctionDuration;
+        emit SetControlAuctionDuration(_controlAuctionDuration);
+    }
+
+    function setControlDuration(uint256 _controlDuration) external onlyOwner {
+        controlDuration = _controlDuration;
+        emit SetControlDuration(_controlDuration);
+    }
+}
+
+/*
+controlAuctionStartTimestamp = 0
+controlAuctionEndTimestamp = 0
+
+submitControlBid()
+    1) if there are no bids
+        set controlAuctionTimestamp (start the auction)
+    2) else if timestamp > controlAuctionTimestamp + controlAuctionDuration
+        revert because the auction is over
+    3) set the new best bid, emit NewControlBid event, transfer tokens
+
+endControlAuction()
+    1) if there are no bids
+        revert because the auction has not started yet
+    2) if timestamp < controlAuctionTimestamp + controlAuctionDuration
+        revert because the auction is in progress
+    3) reset the best bid, emit Control event, transfer tokens, set controlAuctionEndTimestamp
+    
+if controlEndTimestamp > controlStartTimestamp
+    auction not started, submit a bid to start it
+
+if timestamp < controlStartTimestamp + controlAuctionDuration
+    auction is in progress
+
+if timestamp > controlStartTimestamp + controlAuctionDuration
+    auction is over, waiting for endControlAuction()
+
+if timestamp < controlAuctionEndTimestamp + controlDuration
+    control is active
+
+*/

--- a/audit/src/Poke.sol
+++ b/audit/src/Poke.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+
+/// @title An experiment in collaborative gaming
+/// @author olias.eth
+/// @notice This is experimental software, use at your own risk.
+contract Poke is ERC20, Ownable {
+    /* -------------------------------------------------------------------------- */
+    /*                                   STORAGE                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Address of the current game contract
+    address public gameAddress;
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   EVENTS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    event SetGameAddress(address gameAddress);
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   ERRORS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    error NotAuthorized();
+
+    /* -------------------------------------------------------------------------- */
+    /*                                 MODIFIERS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Requires the sender to be the game contract
+    modifier onlyGameAddress() {
+        if (msg.sender != gameAddress) {
+            revert NotAuthorized();
+        }
+        _;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                               INITIALIZATION                               */
+    /* -------------------------------------------------------------------------- */
+
+    constructor() ERC20("ethplays", "POKE") {}
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   GAME                                     */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Mint new tokens to an account. Can only be called by the game contract.
+    /// @param account The account to mint tokens to
+    /// @param amount The amount of tokens to mint
+    function gameMint(address account, uint256 amount)
+        external
+        onlyGameAddress
+    {
+        _mint(account, amount);
+    }
+
+    /// @notice Burn existing tokens belonging to an account. Can only be called by the game contract.
+    /// @param account The account to burn tokens for
+    /// @param amount The amount of tokens to burn
+    function gameBurn(address account, uint256 amount)
+        external
+        onlyGameAddress
+    {
+        _burn(account, amount);
+    }
+
+    /// @notice Transfer tokens without approval. Can only be called by the game contract.
+    /// @param from The account to transfer tokens from
+    /// @param to The account to transfer tokens to
+    /// @param amount The amount of tokens to transfer
+    function gameTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) external onlyGameAddress {
+        _transfer(from, to, amount);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   OWNER                                    */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Update the game contract address. Only owner.
+    /// @param _gameAddress The address of the active game
+    function setGameAddress(address _gameAddress) external onlyOwner {
+        gameAddress = _gameAddress;
+        emit SetGameAddress(_gameAddress);
+    }
+}

--- a/audit/src/Registry.sol
+++ b/audit/src/Registry.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+/// @title Registration contract for ethplays
+/// @author olias.eth
+/// @notice This is experimental software, use at your own risk.
+contract Registry is Ownable {
+    /* -------------------------------------------------------------------------- */
+    /*                                   STORAGE                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Boolean indicating if registration is currently active
+    bool public isActive = true;
+    /// @notice Registration fee amount in ether
+    uint256 public registrationFee = 0.1 ether;
+
+    /// @notice Registered account addresses by burner account address
+    mapping(address => address) public accounts;
+    /// @notice Burner account addresses by registered account address
+    mapping(address => address) public burnerAccounts;
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   EVENTS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    event NewRegistration(address account, address burnerAccount);
+    event UpdatedRegistration(address account, address burnerAccount);
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   ERRORS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    error RegistrationNotActive();
+    error BurnerAccountAlreadyRegistered();
+    error AccountAlreadyRegistered();
+    error AccountNotRegistered();
+    error IncorrectRegistrationFee();
+
+    /* -------------------------------------------------------------------------- */
+    /*                                 MODIFIERS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Requires the game to be active
+    modifier onlyActive() {
+        if (!isActive) {
+            revert RegistrationNotActive();
+        }
+        _;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                REGISTRATION                                */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Register for ethplays!
+    /// @param burnerAccount The address of the burner account to be registered
+    function register(address burnerAccount) external payable onlyActive {
+        if (accounts[burnerAccount] != address(0)) {
+            revert BurnerAccountAlreadyRegistered();
+        }
+
+        if (burnerAccounts[msg.sender] != address(0)) {
+            revert AccountAlreadyRegistered();
+        }
+
+        if (msg.value != registrationFee) {
+            revert IncorrectRegistrationFee();
+        }
+
+        accounts[burnerAccount] = msg.sender;
+        burnerAccounts[msg.sender] = burnerAccount;
+
+        emit NewRegistration(msg.sender, burnerAccount);
+    }
+
+    /// @notice Update the burner account address for a registered account
+    /// @param burnerAccount The address of the new burner account to be registered
+    function updateBurnerAccount(address burnerAccount) external onlyActive {
+        if (accounts[burnerAccount] != address(0)) {
+            revert BurnerAccountAlreadyRegistered();
+        }
+
+        if (burnerAccounts[msg.sender] == address(0)) {
+            revert AccountNotRegistered();
+        }
+
+        accounts[burnerAccount] = msg.sender;
+        burnerAccounts[msg.sender] = burnerAccount;
+
+        emit UpdatedRegistration(msg.sender, burnerAccount);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   ADMIN                                    */
+    /* -------------------------------------------------------------------------- */
+
+    function setIsActive(bool _isActive) external onlyOwner {
+        isActive = _isActive;
+    }
+
+    function setRegistrationFee(uint256 _registrationFee) external onlyOwner {
+        registrationFee = _registrationFee;
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                 WITHDRAWAL                                 */
+    /* -------------------------------------------------------------------------- */
+
+    function withdrawAll(address withdrawTo) external onlyOwner {
+        payable(withdrawTo).transfer(address(this).balance);
+    }
+
+    function withdrawAllERC20(address withdrawTo, IERC20 erc20Token)
+        external
+        onlyOwner
+    {
+        erc20Token.transfer(withdrawTo, erc20Token.balanceOf(address(this)));
+    }
+}

--- a/audit/src/RegistryReceiverV0.sol
+++ b/audit/src/RegistryReceiverV0.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+
+/// @title Child registry for EthPlays
+/// @author olias.eth
+/// @notice This is experimental software, use at your own risk.
+contract RegistryReceiverV0 is Ownable {
+    /* -------------------------------------------------------------------------- */
+    /*                                   STORAGE                                  */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice [State] Registered account addresses by burner account address
+    mapping(address => address) public accounts;
+    /// @notice [State] Burner account addresses by registered account address
+    mapping(address => address) public burnerAccounts;
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   EVENTS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    event NewRegistration(address account, address burnerAccount);
+    event UpdatedRegistration(
+        address account,
+        address burnerAccount,
+        address previousBurnerAccount
+    );
+
+    /* -------------------------------------------------------------------------- */
+    /*                                REGISTRATION                                */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Returns true if the specified burner account is registered.
+    /// @param burnerAccount The address of the players burner account
+    /// @return isRegistered True if the burner account is registered
+    function isRegistered(address burnerAccount) public view returns (bool) {
+        return accounts[burnerAccount] != address(0);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                REGISTRATION                                */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Registers a new account to burner account mapping. Owner only.
+    /// @param account The address of the players main account
+    /// @param burnerAccount The address of the players burner account
+    function submitRegistration(address account, address burnerAccount)
+        external
+        onlyOwner
+    {
+        address previousBurnerAccount = burnerAccounts[account];
+
+        if (previousBurnerAccount != address(0)) {
+            emit UpdatedRegistration(
+                account,
+                burnerAccount,
+                previousBurnerAccount
+            );
+        } else {
+            emit NewRegistration(account, burnerAccount);
+        }
+
+        accounts[burnerAccount] = account;
+        burnerAccounts[account] = burnerAccount;
+    }
+}

--- a/audit/test/Deploy.t.sol
+++ b/audit/test/Deploy.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Registry} from "src/Registry.sol";
+import {RegistryReceiverV0} from "src/RegistryReceiverV0.sol";
+import {Poke} from "src/Poke.sol";
+import {EthPlaysV0} from "src/EthPlaysV0.sol";
+
+contract Deploy is Test {
+    Registry registry;
+    RegistryReceiverV0 registryReceiver;
+    Poke poke;
+    EthPlaysV0 ethPlays;
+
+    function testDeploy() external {
+        registry = new Registry();
+        assertEq(registry.isActive(), true);
+        assertEq(registry.registrationFee(), 0.1 ether);
+
+        registryReceiver = new RegistryReceiverV0();
+
+        poke = new Poke();
+
+        ethPlays = new EthPlaysV0(poke, registryReceiver);
+        assertEq(ethPlays.isActive(), true);
+        assertEq(address(ethPlays.poke()), address(poke));
+        assertEq(
+            address(ethPlays.registryReceiver()),
+            address(registryReceiver)
+        );
+
+        poke.setGameAddress(address(ethPlays));
+        assertEq(poke.gameAddress(), address(ethPlays));
+    }
+}

--- a/audit/test/Integration.t.sol
+++ b/audit/test/Integration.t.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Poke} from "src/Poke.sol";
+import {RegistryReceiverV0} from "src/RegistryReceiverV0.sol";
+import {EthPlaysV0} from "src/EthPlaysV0.sol";
+
+contract IntegrationTest is Test {
+    // Test storage
+    Poke poke;
+    RegistryReceiverV0 registryReceiver;
+    EthPlaysV0 ethPlays;
+
+    address deployer;
+    address constant alice = address(1);
+    address constant bob = address(2);
+    address constant charlie = address(3);
+
+    // EthPlays parameters
+    uint256 alignmentVoteCooldown;
+    uint256 chaosVoteReward;
+    uint256 orderDuration;
+    uint256 chaosInputRewardCooldown;
+    uint256 orderInputReward;
+    uint256 chaosInputReward;
+    uint256 controlAuctionDuration;
+    uint256 controlDuration;
+
+    // Poke events
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    // EthPlays events
+    event AlignmentVote(address from, bool vote, int256 alignment);
+    event InputVote(uint256 inputIndex, address from, uint256 buttonIndex);
+    event ButtonInput(uint256 inputIndex, address from, uint256 buttonIndex);
+    event NewControlBid(address from, uint256 amount);
+    event Control(address from);
+
+    function setUp() public {
+        deployer = address(this);
+        poke = new Poke();
+        registryReceiver = new RegistryReceiverV0();
+        ethPlays = new EthPlaysV0(poke, registryReceiver);
+        poke.setGameAddress(address(ethPlays));
+        vm.roll(1);
+        skip(1000);
+
+        // Bind EthPlays parameters.
+        alignmentVoteCooldown = ethPlays.alignmentVoteCooldown();
+        chaosVoteReward = ethPlays.chaosVoteReward();
+        orderDuration = ethPlays.orderDuration();
+        chaosInputRewardCooldown = ethPlays.chaosInputRewardCooldown();
+        orderInputReward = ethPlays.orderInputReward();
+        chaosInputReward = ethPlays.chaosInputReward();
+        controlAuctionDuration = ethPlays.controlAuctionDuration();
+        controlDuration = ethPlays.controlDuration();
+    }
+
+    function registerAccounts() public {
+        registryReceiver.submitRegistration(address(10), alice);
+        registryReceiver.submitRegistration(address(20), bob);
+        registryReceiver.submitRegistration(address(30), charlie);
+    }
+
+    function mine() public {
+        vm.roll(block.number + 1);
+        skip(2);
+    }
+
+    function dealPoke(address account, uint256 amount) public {
+        vm.startPrank(address(ethPlays));
+        poke.gameMint(account, amount);
+        vm.stopPrank();
+    }
+
+    function testInitialParameters() public {
+        assertEq(poke.gameAddress(), address(ethPlays));
+        assertEq(address(ethPlays.poke()), address(poke));
+        assertEq(
+            address(ethPlays.registryReceiver()),
+            address(registryReceiver)
+        );
+
+        assertEq(ethPlays.isActive(), true);
+        assertEq(ethPlays.alignmentVoteCooldown(), 60);
+        assertEq(ethPlays.alignmentDecayRate(), 985);
+        assertEq(ethPlays.chaosVoteReward(), 40e18);
+
+        assertEq(ethPlays.orderDuration(), 20);
+
+        assertEq(ethPlays.orderInputReward(), 20e18);
+        assertEq(ethPlays.chaosInputReward(), 20e18);
+        assertEq(ethPlays.chatCost(), 20e18);
+        assertEq(ethPlays.rareCandyCost(), 200e18);
+
+        assertEq(ethPlays.controlAuctionDuration(), 90);
+        assertEq(ethPlays.controlDuration(), 30);
+    }
+
+    function testSubmitAlignmentVoteNotRegistered() public {
+        vm.startPrank(alice);
+        vm.expectRevert(EthPlaysV0.AccountNotRegistered.selector);
+        ethPlays.submitAlignmentVote(true);
+    }
+
+    function testSubmitAlignmentVote() public {
+        registerAccounts();
+        vm.startPrank(alice);
+
+        // It updates the alignment value.
+        ethPlays.submitAlignmentVote(true);
+        assertEq(ethPlays.alignment(), 1000);
+
+        // It reverts if the alignment cooldown has not passed.
+        vm.expectRevert(EthPlaysV0.AlignmentVoteCooldown.selector);
+        ethPlays.submitAlignmentVote(true);
+
+        // It emits the AlignmentVote event and updates the alignment value with decay.
+        vm.warp(block.timestamp + 60);
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit AlignmentVote(alice, true, 1985);
+        ethPlays.submitAlignmentVote(true);
+        assertEq(ethPlays.alignment(), 1985);
+
+        // It mints chaosVoteReward POKE to the sender if voting for Chaos.
+        skip(alignmentVoteCooldown + 1);
+        ethPlays.submitAlignmentVote(false);
+        assertEq(poke.balanceOf(alice), chaosVoteReward);
+    }
+
+    function testSubmitButtonInputNotRegistered() public {
+        vm.startPrank(alice);
+        vm.expectRevert(EthPlaysV0.AccountNotRegistered.selector);
+        ethPlays.submitButtonInput(0);
+    }
+
+    function testSubmitButtonInputChaos() public {
+        registerAccounts();
+        vm.startPrank(alice);
+
+        // It mints reward tokens (if cooldown has passed).
+        vm.expectEmit(false, false, false, true, address(poke));
+        emit Transfer(address(0), alice, chaosInputReward);
+        ethPlays.submitButtonInput(6);
+        assertEq(poke.balanceOf(alice), chaosInputReward * 1);
+
+        // It increments the inputIndex.
+        assertEq(ethPlays.inputIndex(), 1);
+        ethPlays.submitButtonInput(2);
+        assertEq(ethPlays.inputIndex(), 2);
+        // It doesn't mint reward tokens (if cooldown has not passed).
+        assertEq(poke.balanceOf(alice), chaosInputReward * 1);
+
+        // It emits the ButtonInput event.
+        mine();
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit ButtonInput(3, alice, 5);
+        ethPlays.submitButtonInput(5);
+
+        // It mints reward tokens (if cooldown has passed).
+        skip(chaosInputRewardCooldown + 1);
+        ethPlays.submitButtonInput(5);
+        assertEq(poke.balanceOf(alice), chaosInputReward * 2);
+
+        // It mints reward tokens (if cooldown has passed, even if the user submitted during cooldown).
+        skip(chaosInputRewardCooldown / 2 + 1);
+        ethPlays.submitButtonInput(5);
+        assertEq(poke.balanceOf(alice), chaosInputReward * 2);
+        skip(chaosInputRewardCooldown / 2 + 1);
+        ethPlays.submitButtonInput(5);
+        assertEq(poke.balanceOf(alice), chaosInputReward * 3);
+    }
+
+    function testSubmitButtonInputOrder() public {
+        registerAccounts();
+        vm.startPrank(alice);
+        ethPlays.submitAlignmentVote(true);
+
+        assertEq(ethPlays.inputIndex(), 0);
+
+        // It executes the order ButtonInput
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit ButtonInput(0, alice, 2);
+        ethPlays.submitButtonInput(2);
+        assertEq(ethPlays.inputIndex(), 1);
+
+        // It emits the InputVote event and mints orderInputReward to the sender
+        mine();
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit InputVote(1, alice, 3);
+        ethPlays.submitButtonInput(3);
+        assertEq(poke.balanceOf(alice), orderInputReward);
+
+        // It reverts if submitting for the 2nd time for the same inputIndex
+        vm.expectRevert(EthPlaysV0.AlreadyVotedForThisInput.selector);
+        ethPlays.submitButtonInput(4);
+    }
+
+    function testSubmitButtonInputControl() public {
+        registerAccounts();
+        dealPoke(alice, 100e18);
+        vm.startPrank(alice);
+
+        ethPlays.submitControlBid(1e18);
+        skip(controlAuctionDuration + 1);
+        ethPlays.endControlAuction();
+
+        // It succeeds if the auction winner submits an input
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit ButtonInput(0, alice, 2);
+        ethPlays.submitButtonInput(2);
+
+        vm.stopPrank();
+        vm.startPrank(bob);
+
+        // It reverts if another player submits an input
+        vm.expectRevert(EthPlaysV0.AnotherPlayerHasControl.selector);
+        ethPlays.submitButtonInput(5);
+
+        // It succeeds if the control duration has passed
+        skip(controlDuration + 1);
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit ButtonInput(1, bob, 4);
+        ethPlays.submitButtonInput(4);
+    }
+
+    function testControlAuction() public {
+        registerAccounts();
+        dealPoke(alice, 100e18);
+        vm.startPrank(alice);
+
+        // It burns bid balance.
+        ethPlays.submitControlBid(1e18);
+        assertEq(poke.balanceOf(alice), 99e18);
+
+        vm.stopPrank();
+        dealPoke(bob, 100e18);
+        vm.startPrank(bob);
+
+        // It mints bid balance to the previous bidder when a new best bid is submitted.
+        ethPlays.submitControlBid(3e18);
+        assertEq(poke.balanceOf(alice), 100e18);
+        assertEq(poke.balanceOf(bob), 97e18);
+
+        vm.stopPrank();
+        vm.startPrank(alice);
+
+        // It emits the NewControlBid event.
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit NewControlBid(alice, 10e18);
+        ethPlays.submitControlBid(10e18);
+
+        vm.stopPrank();
+        vm.startPrank(bob);
+
+        // It reverts if the bid does not beat the current best bid.
+        vm.expectRevert(EthPlaysV0.InsufficientBidAmount.selector);
+        ethPlays.submitControlBid(5e18);
+
+        // It reverts if the auction duration has passed.
+        skip(controlAuctionDuration + 1);
+        vm.expectRevert(EthPlaysV0.AuctionIsOver.selector);
+        ethPlays.submitControlBid(12e18);
+
+        // When submitting endControlAuction...
+        // It succeeds, emits the event, and sets the control address.
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit Control(alice);
+        ethPlays.endControlAuction();
+        assertEq(ethPlays.controlAddress(), alice);
+
+        // It reverts if the auction has no bids.
+        vm.expectRevert(EthPlaysV0.AuctionHasNoBids.selector);
+        ethPlays.endControlAuction();
+
+        // It reverts if the auction has a bid but is still in progress.
+        ethPlays.submitControlBid(1e18);
+        vm.expectRevert(EthPlaysV0.AuctionInProgress.selector);
+        ethPlays.endControlAuction();
+
+        // It succeeds if the auction has a bid and auctionDuration has passed.
+        skip(controlAuctionDuration + 1);
+        vm.expectEmit(false, false, false, true, address(ethPlays));
+        emit Control(bob);
+        ethPlays.endControlAuction();
+    }
+
+    // TODO: testSubmitChat()
+    // TODO: testSubmitRareCandies()
+
+    // TODO: testSetIsActive()
+}

--- a/audit/test/Poke.t.sol
+++ b/audit/test/Poke.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Poke} from "src/Poke.sol";
+
+contract PokeTest is Test {
+    Poke poke;
+
+    address deployer = address(0);
+    address constant alice = address(1);
+    address constant bob = address(2);
+    address constant charlie = address(3);
+
+    function setUp() public {
+        poke = new Poke();
+        deployer = address(this);
+    }
+
+    function testInitialGameAddress() public {
+        assertEq(poke.gameAddress(), address(0));
+    }
+
+    function testUpdateGameAddressAsOwner() public {
+        hoax(deployer);
+        poke.setGameAddress(address(5));
+        assertEq(poke.gameAddress(), address(5));
+    }
+
+    function testUpdateGameAddressAsNotOwner() public {
+        hoax(bob);
+        vm.expectRevert("Ownable: caller is not the owner");
+        poke.setGameAddress(address(5));
+    }
+
+    function testMintAsGameContract() public {
+        hoax(deployer);
+        poke.setGameAddress(bob);
+
+        hoax(bob);
+        poke.gameMint(alice, 1e18);
+        assertEq(poke.balanceOf(alice), 1e18);
+    }
+
+    function testMintAsNotGameContract() public {
+        hoax(deployer);
+        poke.setGameAddress(bob);
+
+        hoax(alice);
+        vm.expectRevert(Poke.NotAuthorized.selector);
+        poke.gameMint(alice, 1e18);
+    }
+
+    function testBurnAsGameContract() public {
+        hoax(deployer);
+        poke.setGameAddress(bob);
+
+        hoax(bob);
+        poke.gameMint(alice, 3e18);
+        hoax(bob);
+        poke.gameBurn(alice, 1e18);
+        assertEq(poke.balanceOf(alice), 2e18);
+    }
+
+    function testBurnAsNotGameContract() public {
+        hoax(deployer);
+        poke.setGameAddress(bob);
+
+        hoax(alice);
+        vm.expectRevert(Poke.NotAuthorized.selector);
+        poke.gameBurn(alice, 1e18);
+    }
+
+    function testTransferAsGameContract() public {
+        hoax(deployer);
+        poke.setGameAddress(bob);
+
+        hoax(bob);
+        poke.gameMint(alice, 3e18);
+        hoax(bob);
+        poke.gameTransfer(alice, charlie, 1e18);
+        assertEq(poke.balanceOf(alice), 2e18);
+        assertEq(poke.balanceOf(charlie), 1e18);
+    }
+
+    function testTransferAsNotGameContract() public {
+        hoax(deployer);
+        poke.setGameAddress(bob);
+
+        hoax(alice);
+        vm.expectRevert(Poke.NotAuthorized.selector);
+        poke.gameTransfer(alice, charlie, 1e18);
+    }
+}

--- a/audit/test/Registry.t.sol
+++ b/audit/test/Registry.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {Registry} from "src/Registry.sol";
+
+contract RegistryTest is Test {
+    Registry registry;
+
+    address deployer;
+    address constant alice = address(1);
+    address constant bob = address(2);
+    address constant charlie = address(3);
+
+    event NewRegistration(address account, address burnerAccount);
+    event UpdatedRegistration(address account, address burnerAccount);
+
+    function setUp() public {
+        deployer = address(this);
+        registry = new Registry();
+
+        vm.deal(deployer, 1 ether);
+        vm.deal(alice, 1 ether);
+        vm.deal(bob, 1 ether);
+        vm.deal(charlie, 1 ether);
+    }
+
+    function testRegister() public {
+        // it reverts if registration is not active
+        vm.startPrank(deployer);
+        registry.setIsActive(false);
+        vm.expectRevert(Registry.RegistrationNotActive.selector);
+        registry.register(address(10));
+        registry.setIsActive(true);
+
+        // it reverts if the fee is incorrect
+        vm.stopPrank();
+        vm.startPrank(alice);
+        vm.expectRevert(Registry.IncorrectRegistrationFee.selector);
+        registry.register(address(10));
+
+        // it emits the event and sets the accounts in storage if successful
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit NewRegistration(alice, address(11));
+        registry.register{value: 0.1 ether}(address(11));
+        assertEq(registry.accounts(address(11)), alice);
+        assertEq(registry.burnerAccounts(alice), address(11));
+
+        // it reverts if the sender is already registered
+        vm.expectRevert(Registry.AccountAlreadyRegistered.selector);
+        registry.register{value: 0.1 ether}(address(12));
+
+        // it reverts if the burner account is already taken
+        vm.stopPrank();
+        vm.startPrank(bob);
+        vm.expectRevert(Registry.BurnerAccountAlreadyRegistered.selector);
+        registry.register{value: 0.1 ether}(address(11));
+    }
+
+    function testUpdateBurnerAccount() public {
+        // it reverts if registration is not active
+        vm.startPrank(deployer);
+        registry.setIsActive(false);
+        vm.expectRevert(Registry.RegistrationNotActive.selector);
+        registry.updateBurnerAccount(address(10));
+        registry.setIsActive(true);
+
+        // it reverts if the sender is not already registered
+        vm.stopPrank();
+        vm.startPrank(alice);
+        vm.expectRevert(Registry.AccountNotRegistered.selector);
+        registry.updateBurnerAccount(address(12));
+
+        // it emits the event and sets the accounts in storage if successful
+        registry.register{value: 0.1 ether}(address(10));
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit UpdatedRegistration(alice, address(11));
+        registry.updateBurnerAccount(address(11));
+        assertEq(registry.accounts(address(11)), alice);
+        assertEq(registry.burnerAccounts(alice), address(11));
+
+        // it reverts if the burner account is already taken
+        vm.stopPrank();
+        vm.startPrank(bob);
+        vm.expectRevert(Registry.BurnerAccountAlreadyRegistered.selector);
+        registry.updateBurnerAccount(address(11));
+    }
+
+    function testSetIsActive() public {
+        // it reverts if the sender is not the owner
+        hoax(alice);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.setIsActive(false);
+
+        // it sets the game as inactive if successful
+        hoax(deployer);
+        registry.setIsActive(false);
+        assertEq(registry.isActive(), false);
+    }
+
+    function testSetRegistrationFee() public {
+        // it reverts if the sender is not the owner
+        hoax(charlie);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.setIsActive(false);
+
+        hoax(deployer);
+        registry.setRegistrationFee(0.05 ether);
+        assertEq(registry.registrationFee(), 0.05 ether);
+
+        hoax(alice);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit NewRegistration(alice, address(10));
+        registry.register{value: 0.05 ether}(address(10));
+    }
+}

--- a/audit/test/RegistryReceiverV0.t.sol
+++ b/audit/test/RegistryReceiverV0.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {RegistryReceiverV0} from "src/RegistryReceiverV0.sol";
+
+contract RegistryReceiverV0Test is Test {
+    RegistryReceiverV0 registry;
+
+    address deployer;
+    address constant alice = address(1);
+    address constant bob = address(2);
+    address constant charlie = address(3);
+
+    event NewRegistration(address account, address burnerAccount);
+    event UpdatedRegistration(
+        address account,
+        address burnerAccount,
+        address previousBurnerAccount
+    );
+
+    function setUp() public {
+        deployer = address(this);
+        registry = new RegistryReceiverV0();
+    }
+
+    function testSubmitRegistration() public {
+        hoax(deployer);
+        registry.submitRegistration(address(10), alice);
+        assertEq(registry.accounts(alice), address(10));
+        assertEq(registry.burnerAccounts(address(10)), alice);
+
+        hoax(deployer);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit NewRegistration(address(20), bob);
+        registry.submitRegistration(address(20), bob);
+
+        hoax(deployer);
+        vm.expectEmit(false, false, false, true, address(registry));
+        emit UpdatedRegistration(address(20), charlie, bob);
+        registry.submitRegistration(address(20), charlie);
+    }
+
+    function testSubmitRegistrationAsNotOwner() public {
+        hoax(bob);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.submitRegistration(address(10), alice);
+    }
+}


### PR DESCRIPTION
This PR copy-pastes the `src` and `test` folders so they can be viewed/commented on as a diff.

## ethplays-contracts

- This repo uses [foundry](https://github.com/foundry-rs/foundry)
- This is a WIP, test coverage is incomplete

### Poke.sol

An ownable ERC20 token contract with minor modifications. `Poke` defines three external methods that can only be called by the `EthPlays` contract:

- `gameMint(address,uint256)`: verifies that the sender is the game contract, then calls `_mint()`
- `gameBurn(address,uint256)`: verifies that the sender is the game contract, then calls `_burn()`
- `gameTransfer(address,address,uint256)`: verifies that the sender is the game contract, then calls `_transfer()`

### EthPlays.sol

An ownable contract that defines the game logic. This includes button presses, order & chaos mode, the control auction, and rare candies. `EthPlays` calls both `Poke` and `RegistryReceiver` to mint/burn/transfer tokens and check registration eligibility.

#### Token mechanics

The following actions mint/burn the POKE token:
- Submit a button press (mints 20 POKE to the sender, minting is rate-limited to once per 30 seconds)
- Submit an alignment vote for chaos (mints 40 POKE to the sender, players can only vote for alignment once per minute)
- Submit a message to the chat (burns 20 POKE)
- Purchase rare candies (burns 200 POKE per rare candy)
- Submit a control bid (burns the bid amount of POKE, mints the previous best bid amount to the previous best bid sender)

#### Auction mechanics

EthPlays defines a simple auction mechanism using the POKE token. Players can submit bids (in POKE) to take control of the game for 30 seconds. The auction lasts 90 seconds, and once ended, the next auction begins immediately. If a player submits a bid that beats the previous bid, the POKE amount from the previous bid is minted back to the the sender of that bid. The POKE amount of the winning bid gets burned.

Auction state:
- controlAuctionStartTimestamp
- controlAuctionEndTimestamp
- bestControlBid
- controlAddress

Auction parameters:
- controlAuctionDuration
- controlDuration

How to derive auction status from contract state:
- if (controlEndTimestamp > controlStartTimestamp) -> the auction is ready, submit a bid to start it
- if (timestamp < controlAuctionStartTimestamp + controlAuctionDuration) -> auction is in progress
- if (timestamp > controlAuctionStartTimestamp + controlAuctionDuration) -> auction is over, waiting to be ended
- if (timestamp < controlAuctionEndTimestamp + controlDuration) -> control is active

### Registry.sol

An ownable contract _on mainnet_ that players interact with to register for the game. This contract holds registration fees which can be withdrawn by the owner. The `RegistryReceiver` contract mirrors the registration data stored on this contract.

### RegistryReceiver.sol

An ownable contract storing registration data. `EthPlays` calls the public `isRegistered(address)` method to determine if an account is allowed to play. This contract is upgradable, so it could be updated with new registration rules (e.g. an allowlist).

### Offchain relayer/faucet

There is an offchain web service that responds to `NewRegistration` and `UpdatedRegistration` events emitted by the `Registry` contract on mainnet and does two things:
* Calls the `submitRegistration(address,address)` method on `RegistryReceiver` with the account/burner account from the `Register` event.
* Sends faucet funds to the burner account specified in the `Register` event.

